### PR TITLE
Removing temp. file left behind after conda installs/updates PSI4

### DIFF
--- a/conda-recipes/psi4/post-link.sh
+++ b/conda-recipes/psi4/post-link.sh
@@ -9,7 +9,7 @@ echo "    Inputs:  ${PREFIX}/share/psi4/samples"
 echo "    Manual:  http://psicode.org/psi4manual/master/index.html"
 echo "    GitHub:  https://github.com/psi4/psi4/wiki"
 echo "    Binary:  https://anaconda.org/psi4"
-#echo "    Runtime Environment Diagnostic: ${PREFIX}/share/psi4/scripts/setenv.py"
+# echo "    Runtime Environment Diagnostic: ${PREFIX}/share/psi4/scripts/setenv.py"
 echo "    Youtube: https://www.youtube.com/user/psitutorials"
 echo ""
 echo "  For csh/tcsh command-line use, add to shell or ~/.tcshrc file:"
@@ -30,41 +30,41 @@ echo ""
 
 # removed b/c install env may not have numpy so test can't run
 #
-# create input file
-#cat > linktest.in << EOL
-#memory 250 mb
+# # create input file
+# cat > linktest.in << EOL
+# memory 250 mb
 #
-#molecule dimer {
-#0 1
-#C   0.000000  -0.667578  -2.124659
-#C   0.000000   0.667578  -2.124659
-#H   0.923621  -1.232253  -2.126185
-#H  -0.923621  -1.232253  -2.126185
-#H  -0.923621   1.232253  -2.126185
-#H   0.923621   1.232253  -2.126185
-#--
-#0 1
-#C   0.000000   0.000000   2.900503
-#C   0.000000   0.000000   1.693240
-#H   0.000000   0.000000   0.627352
-#H   0.000000   0.000000   3.963929
-#}
+# molecule dimer {
+# 0 1
+# C   0.000000  -0.667578  -2.124659
+# C   0.000000   0.667578  -2.124659
+# H   0.923621  -1.232253  -2.126185
+# H  -0.923621  -1.232253  -2.126185
+# H  -0.923621   1.232253  -2.126185
+# H   0.923621   1.232253  -2.126185
+# --
+# 0 1
+# C   0.000000   0.000000   2.900503
+# C   0.000000   0.000000   1.693240
+# H   0.000000   0.000000   0.627352
+# H   0.000000   0.000000   3.963929
+# }
 #
-#set {
-#  BASIS jun-cc-pVDZ
-#  SCF_TYPE DF
-#  FREEZE_CORE True
-#}
+# set {
+#   BASIS jun-cc-pVDZ
+#   SCF_TYPE DF
+#   FREEZE_CORE True
+# }
 #
-#energy('sapt0')
+# energy('sapt0')
 #
-#compare_values(85.189064196429, dimer.nuclear_repulsion_energy(), 9, "Nuclear Repulsion Energy")
-#compare_values(-0.003378388762, psi4.get_variable("SAPT ELST ENERGY"), 6, "SAPT0 Eelst")
-#compare_values( 0.003704416103, psi4.get_variable("SAPT EXCH ENERGY"), 6, "SAPT0 Eexch")
-#compare_values(-0.000889316601, psi4.get_variable("SAPT IND ENERGY"), 6, "SAPT0 Eind")
-#compare_values(-0.001672292164, psi4.get_variable("SAPT DISP ENERGY"), 6, "SAPT0 Edisp")
-#compare_values(-0.002235581423, psi4.get_variable("SAPT SAPT0 ENERGY"), 6, "SAPT0 Etotal")
-#EOL
+# compare_values(85.189064196429, dimer.nuclear_repulsion_energy(), 9, "Nuclear Repulsion Energy")
+# compare_values(-0.003378388762, psi4.get_variable("SAPT ELST ENERGY"), 6, "SAPT0 Eelst")
+# compare_values( 0.003704416103, psi4.get_variable("SAPT EXCH ENERGY"), 6, "SAPT0 Eexch")
+# compare_values(-0.000889316601, psi4.get_variable("SAPT IND ENERGY"), 6, "SAPT0 Eind")
+# compare_values(-0.001672292164, psi4.get_variable("SAPT DISP ENERGY"), 6, "SAPT0 Edisp")
+# compare_values(-0.002235581423, psi4.get_variable("SAPT SAPT0 ENERGY"), 6, "SAPT0 Etotal")
+# EOL
 #
 # # run test calculation
 # PSIOUT=`PSI_SCRATCH=/tmp; ${PREFIX}/bin/psi4 -i linktest.in -o linktest.out > linktest.txt`

--- a/conda-recipes/psi4/post-link.sh
+++ b/conda-recipes/psi4/post-link.sh
@@ -28,43 +28,44 @@ echo ""
 echo "  Report problems at http://forum.psicode.org/t/report-conda-update-psi4-oddities-here/32"
 echo ""
 
-# create input file
-cat > linktest.in << EOL
-memory 250 mb
-
-molecule dimer {
-0 1
-C   0.000000  -0.667578  -2.124659
-C   0.000000   0.667578  -2.124659
-H   0.923621  -1.232253  -2.126185
-H  -0.923621  -1.232253  -2.126185
-H  -0.923621   1.232253  -2.126185
-H   0.923621   1.232253  -2.126185
---
-0 1
-C   0.000000   0.000000   2.900503
-C   0.000000   0.000000   1.693240
-H   0.000000   0.000000   0.627352
-H   0.000000   0.000000   3.963929
-}
-
-set {
-  BASIS jun-cc-pVDZ
-  SCF_TYPE DF
-  FREEZE_CORE True
-}
-
-energy('sapt0')
-
-compare_values(85.189064196429, dimer.nuclear_repulsion_energy(), 9, "Nuclear Repulsion Energy")
-compare_values(-0.003378388762, psi4.get_variable("SAPT ELST ENERGY"), 6, "SAPT0 Eelst")
-compare_values( 0.003704416103, psi4.get_variable("SAPT EXCH ENERGY"), 6, "SAPT0 Eexch")
-compare_values(-0.000889316601, psi4.get_variable("SAPT IND ENERGY"), 6, "SAPT0 Eind")
-compare_values(-0.001672292164, psi4.get_variable("SAPT DISP ENERGY"), 6, "SAPT0 Edisp")
-compare_values(-0.002235581423, psi4.get_variable("SAPT SAPT0 ENERGY"), 6, "SAPT0 Etotal")
-EOL
-
 # removed b/c install env may not have numpy so test can't run
+#
+# create input file
+#cat > linktest.in << EOL
+#memory 250 mb
+#
+#molecule dimer {
+#0 1
+#C   0.000000  -0.667578  -2.124659
+#C   0.000000   0.667578  -2.124659
+#H   0.923621  -1.232253  -2.126185
+#H  -0.923621  -1.232253  -2.126185
+#H  -0.923621   1.232253  -2.126185
+#H   0.923621   1.232253  -2.126185
+#--
+#0 1
+#C   0.000000   0.000000   2.900503
+#C   0.000000   0.000000   1.693240
+#H   0.000000   0.000000   0.627352
+#H   0.000000   0.000000   3.963929
+#}
+#
+#set {
+#  BASIS jun-cc-pVDZ
+#  SCF_TYPE DF
+#  FREEZE_CORE True
+#}
+#
+#energy('sapt0')
+#
+#compare_values(85.189064196429, dimer.nuclear_repulsion_energy(), 9, "Nuclear Repulsion Energy")
+#compare_values(-0.003378388762, psi4.get_variable("SAPT ELST ENERGY"), 6, "SAPT0 Eelst")
+#compare_values( 0.003704416103, psi4.get_variable("SAPT EXCH ENERGY"), 6, "SAPT0 Eexch")
+#compare_values(-0.000889316601, psi4.get_variable("SAPT IND ENERGY"), 6, "SAPT0 Eind")
+#compare_values(-0.001672292164, psi4.get_variable("SAPT DISP ENERGY"), 6, "SAPT0 Edisp")
+#compare_values(-0.002235581423, psi4.get_variable("SAPT SAPT0 ENERGY"), 6, "SAPT0 Etotal")
+#EOL
+#
 # # run test calculation
 # PSIOUT=`PSI_SCRATCH=/tmp; ${PREFIX}/bin/psi4 -i linktest.in -o linktest.out > linktest.txt`
 # echo $PSIOUT


### PR DESCRIPTION
## Description

When conda updates, the unused test file (linktest.in) is left in the current working directory. I assume that the file is no longer needed since the screen output suggests testing with a separate input file (/path/to/samples/stability2/input.dat). This commit stops the file from being created.
## Todos
- [x] Avoids creating linktest.in when conda updates/installs PSI4 
## Status
- [x]  Ready to go
