### PR TITLE
Create build recipes for MDSAPT

### DIFF
--- a/conda-recipes/mdsapt/build.sh
+++ b/conda-recipes/mdsapt/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+python setup.py install
+

--- a/conda-recipes/mdsapt/meta.yaml
+++ b/conda-recipes/mdsapt/meta.yaml
@@ -1,0 +1,57 @@
+package:
+  name: mdsapt
+  version: "{{ GIT_DESCRIBE_TAG }}"
+
+source:
+  git_url: https://github.com/ALescoulie/MDSAPT.git
+  git_tag: 1.0.0
+
+about:
+  home: https://github.com/ALescoulie/MDSAPT
+  license: GPL-3.0
+  license_file: LICENSE
+  license_family: GPL3
+  summary: SAPT Calculations for MDAnalysis
+  doc_url: https://mdsapt.readthedocs.io/
+  dev_url: https://github.com/ALescoulie/MDSAPT
+
+build:
+  # MDSAPT does not support windows.
+  skip: True # [win]
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - psi4
+    - mdanalysis
+    - nglview
+    - numpy
+    - openmm
+    - pandas
+    - pdbfixer
+    - python
+    - pyyaml
+    - rdkit
+
+test:
+  imports:
+    - mdsapt
+    - mdsapt.tests
+  source_files:
+    - mdsapt/**/*
+  requires:
+    - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest -v mdsapt
+
+extra:
+  maintainers:
+   - ALescoulie
+   - astralbijection
+  recipe-maintainers:
+   - ALescoulie
+   - astralbijection

--- a/conda-recipes/mdsapt/meta.yaml
+++ b/conda-recipes/mdsapt/meta.yaml
@@ -3,20 +3,20 @@ package:
   version: "{{ GIT_DESCRIBE_TAG }}"
 
 source:
-  git_url: https://github.com/ALescoulie/MDSAPT.git
+  git_url: https://github.com/calpolyccg/MDSAPT.git
   git_tag: 1.0.0
 
 about:
-  home: https://github.com/ALescoulie/MDSAPT
+  home: https://github.com/calpolyccg/MDSAPT
   license: GPL-3.0
   license_file: LICENSE
   license_family: GPL3
   summary: SAPT Calculations for MDAnalysis
   doc_url: https://mdsapt.readthedocs.io/
-  dev_url: https://github.com/ALescoulie/MDSAPT
+  dev_url: https://github.com/calpolyccg/MDSAPT
 
 build:
-  # MDSAPT does not support windows.
+  # MDSAPT does not officially support windows.
   skip: True # [win]
 
 requirements:
@@ -24,13 +24,13 @@ requirements:
     - python
     - pip
   run:
-    - psi4
     - mdanalysis
     - nglview
     - numpy
     - openmm
     - pandas
     - pdbfixer
+    - psi4
     - python
     - pyyaml
     - rdkit
@@ -55,3 +55,4 @@ extra:
   recipe-maintainers:
    - ALescoulie
    - astralbijection
+


### PR DESCRIPTION
This PR creates a build recipe for MDSAPT (original repo [here](https://github.com/ALescoulie/MDSAPT.git)).

Building it works with the following command:
```
conda build -c psi4 -c conda-forge .
```